### PR TITLE
Restore Categories component (faqCategories) and categorySlug filtering

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -2,8 +2,20 @@
 use System\Classes\PluginBase;
 
 use Backend;
+use Event;
+use Aic\Faq\Models\Categories;
 
 class Plugin extends PluginBase {
+
+    public function boot()
+    {
+        /* URL parameter and query string translation (Winter.Translate locale picker) */
+        Event::listen('translate.localePicker.translateParams', function ($page, $params, $oldLocale, $newLocale) {
+            if ($page->hasComponent('FAQ') || $page->hasComponent('faqCategories')) {
+                return Categories::translateParams($params, $oldLocale, $newLocale);
+            }
+        });
+    }
 
     public function pluginDetails()
     {
@@ -38,6 +50,12 @@ class Plugin extends PluginBase {
                         'url'         => Backend::url('aic/faq/categories'),
                         'icon'        => 'icon-folder-open-o',
                         'order'       => 200
+                    ],
+                    'settings' => [
+                        'label'       => 'aic.faq::lang.menu.settings',
+                        'url'         => Backend::url('aic/faq/settings'),
+                        'icon'        => 'icon-cogs',
+                        'order'       => 300
                     ]
                 ]
             ]

--- a/Plugin.php
+++ b/Plugin.php
@@ -57,7 +57,8 @@ class Plugin extends PluginBase {
     public function registerComponents()
     {
         return [
-            'Aic\Faq\Components\Faqs' => 'FAQ'
+            'Aic\Faq\Components\Faqs' => 'FAQ',
+            'Aic\Faq\Components\Categories' => 'faqCategories'
         ];
     }
     

--- a/components/Categories.php
+++ b/components/Categories.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Aic\Faq\Components;
+
+use Cms\Classes\ComponentBase;
+use Cms\Classes\Page;
+use Lang;
+use Aic\Faq\Models\Categories as FaqCategories;
+
+class Categories extends ComponentBase
+{
+    public $categories;
+    public $oPage;
+    public $categoryPage;
+    public $categorySlug;
+    public $allLabel;
+
+    public function componentDetails()
+    {
+        return [
+            'name' => 'aic.faq::lang.component.categories.title',
+            'description' => 'aic.faq::lang.component.categories.description',
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [
+            'categorySlug' => [
+                'title' => 'aic.faq::lang.component.categories.settings.slug.title',
+                'description' => 'aic.faq::lang.component.categories.settings.slug.description',
+                'type' => 'string',
+                'default' => '{{ :slug }}',
+            ],
+            'oPage' => [
+                'title' => 'aic.faq::lang.component.categories.settings.overview_page.title',
+                'description' => 'aic.faq::lang.component.categories.settings.overview_page.description',
+                'type' => 'dropdown',
+                'group' => 'aic.faq::lang.component.categories.settings.links',
+                'options' => Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName'),
+            ],
+            'categoryPage' => [
+                'title' => 'aic.faq::lang.component.categories.settings.category_page.title',
+                'description' => 'aic.faq::lang.component.categories.settings.category_page.description',
+                'type' => 'dropdown',
+                'group' => 'aic.faq::lang.component.categories.settings.links',
+                'options' => Page::sortBy('baseFileName')->lists('baseFileName', 'baseFileName'),
+            ],
+        ];
+    }
+
+    public function onRun()
+    {
+        $this->prepareVars();
+        $this->categories = FaqCategories::where('is_published', 1)->get();
+    }
+
+    protected function prepareVars()
+    {
+        $this->oPage = $this->property('oPage');
+        $this->categoryPage = $this->property('categoryPage');
+        $this->categorySlug = $this->property('categorySlug');
+        $this->allLabel = Lang::get('aic.faq::lang.component.categories.all_label');
+    }
+}

--- a/components/Faqs.php
+++ b/components/Faqs.php
@@ -4,12 +4,19 @@ use Cms\Classes\ComponentBase;
 use Lang;
 use Aic\Faq\Models\Categories;
 use Aic\Faq\Models\Faqs as Faq;
+use Aic\Faq\Models\Settings;
 
 class Faqs extends ComponentBase
 {
+    public $title;
+    public $intro;
+    public $blocks;
+
     public $faqs;
     public $faqsPerCategory;
     public $isSearch;
+    public $isFilter;
+    public $noPostsMessage;
     public $searchLabel;
     public $searchPlaceholder;
     public $minSearchResults;
@@ -81,6 +88,19 @@ class Faqs extends ComponentBase
                 'type'        => 'string',
                 'default'     => ''
             ],
+            'isFilter' => [
+                'title'       => 'aic.faq::lang.settings.filter_title',
+                'description' => 'aic.faq::lang.settings.filter_description',
+                'default'     => true,
+                'type'        => 'checkbox'
+            ],
+            'noPostsMessage' => [
+                'title'       => 'aic.faq::lang.settings.no_posts_title',
+                'description' => 'aic.faq::lang.settings.no_posts_description',
+                'type'        => 'string',
+                'default'     => Lang::get('aic.faq::lang.settings.no_posts_found'),
+                'showExternalParam' => false
+            ],
         ];
     }
 
@@ -95,9 +115,41 @@ class Faqs extends ComponentBase
     protected function prepareVars()
     {
         $this->isSearch = (int) $this->property('isSearch');
+        $this->isFilter = (int) $this->property('isFilter');
+        $this->noPostsMessage = $this->property('noPostsMessage');
         $this->searchLabel = Lang::get('aic.faq::lang.component.settings.search.button_label');
         $this->searchPlaceholder = Lang::get('aic.faq::lang.component.settings.search.input_placeholder');
         $this->searchQuery = trim(input('q'));
+
+        // title and intro
+        $settings = Settings::instance();
+        $this->title = $settings->title;
+        $this->intro = $settings->intro;
+        $this->blocks = $settings->blocks;
+
+        // set meta
+        $this->setMeta($settings);
+    }
+
+    protected function setMeta($settings)
+    {
+        // create the meta_description
+        $meta_description = strip_tags($settings->intro);
+        if (strlen($meta_description) > 200) {
+            $meta_description = substr($meta_description, 0, 197) . '...';
+        }
+
+        // set title
+        $this->page->title = ($settings->meta_title) ? $settings->meta_title : $settings->title;
+
+        // set meta (try meta_value, else try og_value, else use default value)
+        $this->page->meta_title = ($settings->meta_title) ? $settings->meta_title : ($settings->og_title ? $settings->og_title : $settings->title);
+        $this->page->meta_description = ($settings->meta_description) ? $settings->meta_description : ($settings->og_description ? $settings->og_description : $meta_description);
+
+        // set og (try og_value, else use meta_value)
+        $this->page->og_title = ($settings->og_title) ? $settings->og_title : $this->page->meta_title;
+        $this->page->og_description = ($settings->og_description) ? $settings->og_description : $this->page->meta_description;
+        $this->page->og_image = ($settings->og_image) ? $settings->og_image : null;
     }
 
     protected function showSearch()

--- a/components/Faqs.php
+++ b/components/Faqs.php
@@ -75,6 +75,12 @@ class Faqs extends ComponentBase
                 'default'     => true,
                 'type'        => 'checkbox'
             ],
+            'categorySlug' => [
+                'title'       => 'aic.faq::lang.component.settings.category_slug.title',
+                'description' => 'aic.faq::lang.component.settings.category_slug.description',
+                'type'        => 'string',
+                'default'     => ''
+            ],
         ];
     }
 
@@ -113,10 +119,12 @@ class Faqs extends ComponentBase
 
     protected function getFAQs()
     {
-        
+
+        $categoryId = $this->loadCategory() ?? (int) $this->property('categoryId');
+
         $faqs = Faq::listFrontEnd([
             'sort'         => $this->property('sort'),
-            'categoryId'   => (int) $this->property('categoryId'),
+            'categoryId'   => $categoryId,
             'isFeatured'   => (int) $this->property('isFeatured'),
             'isSearch'     => (int) $this->property('isSearch'),
             'isTranslated' => (int) $this->property('isTranslated'),
@@ -124,6 +132,20 @@ class Faqs extends ComponentBase
         ]);
 
         return $faqs;
+    }
+
+    protected function loadCategory()
+    {
+        $slug = $this->property('categorySlug');
+        if (!$slug) return null;
+
+        $category = new Categories();
+        $category = $category->isClassExtendedWith('Winter.Translate.Behaviors.TranslatableModel')
+            ? $category->transWhere('slug', $slug)
+            : $category->where('slug', $slug);
+        $category = $category->first();
+
+        return $category ? $category->id : null;
     }
 
     protected function faqsPerCategory($faqs)

--- a/components/categories/default.htm
+++ b/components/categories/default.htm
@@ -1,0 +1,19 @@
+{% set categories = __SELF__.categories %}
+{% set oPage = __SELF__.oPage %}
+{% set categoryPage = __SELF__.categoryPage %}
+{% set categorySlug = __SELF__.categorySlug %}
+
+{% if categories|length > 0 %}
+    <nav>
+        <ul>
+            {% if oPage %}
+                <li><a href='{{ oPage | page }}'{% if categorySlug == '' %} class='selected'{% endif %}>{{ __SELF__.allLabel }}</a></li>
+            {% endif %}
+            {% for category in categories %}
+                <li>
+                    <a href='{{ categoryPage | page({ slug: category.slug }) }}'{% if categorySlug == category.slug %} class='selected'{% endif %}>{{ category.name }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+{% endif %}

--- a/controllers/Categories.php
+++ b/controllers/Categories.php
@@ -7,7 +7,8 @@ class Categories extends Controller
 {
     public $implement = [
         \Backend\Behaviors\FormController::class,
-        \Backend\Behaviors\ListController::class
+        \Backend\Behaviors\ListController::class,
+        \Backend\Behaviors\ReorderController::class
     ];
 
     public $bodyClass = 'compact-container';

--- a/controllers/Settings.php
+++ b/controllers/Settings.php
@@ -1,0 +1,51 @@
+<?php namespace Aic\Faq\Controllers;
+use Backend\Classes\Controller;
+
+use Illuminate\Support\Facades\Lang;
+use Flash;
+use Backend;
+use BackendMenu;
+use Aic\Faq\Models\Settings as SettingsModel;
+
+class Settings extends Controller
+{
+    public $implement = [
+        \Backend\Behaviors\FormController::class
+    ];
+
+    public $bodyClass = 'compact-container';
+
+    public function __construct()
+    {
+        parent::__construct();
+        BackendMenu::setContext('Aic.Faq', 'faq', 'settings');
+    }
+
+    /**************************************/
+    // Settings
+    /**************************************/
+    public function index()
+    {
+        $this->pageTitle = Lang::get('aic.faq::lang.menu.settings');
+        $this->asExtension('FormController')->update();
+    }
+
+    public function index_onSave()
+    {
+        return $this->asExtension('FormController')->update_onSave();
+    }
+
+    public function index_onResetDefault()
+    {
+        $model = SettingsModel::instance();
+        $model->resetDefault();
+
+        Flash::success(Lang::get('backend::lang.form.reset_success'));
+        return Backend::redirect('aic/faq/settings');
+    }
+
+    public function formFindModelObject()
+    {
+        return SettingsModel::instance();
+    }
+}

--- a/controllers/categories/_list_toolbar.htm
+++ b/controllers/categories/_list_toolbar.htm
@@ -7,6 +7,13 @@
         <?= e(trans('aic.faq::lang.new.categories')) ?>
     </a>
 
+    <!-- reorder -->
+    <a
+        href="<?= Backend::url('aic/faq/categories/reorder') ?>"
+        class="btn btn-secondary wn-icon-sort">
+        <?= e(trans('aic.faq::lang.button.reorder')) ?>
+    </a>
+
     <?php if (Aic\Faq\Models\Categories::count() > 0): ?>
 
     <!-- remove -->

--- a/controllers/categories/_reorder_toolbar.htm
+++ b/controllers/categories/_reorder_toolbar.htm
@@ -1,0 +1,9 @@
+<div data-control="toolbar">
+
+    <a
+        href="<?= Backend::url('aic/faq/categories') ?>"
+        class="btn btn-primary wn-icon-long-arrow-left">
+        <?= e(trans('aic.faq::lang.menu.categories')) ?>
+    </a>
+
+</div>

--- a/controllers/categories/config_reorder.yaml
+++ b/controllers/categories/config_reorder.yaml
@@ -1,0 +1,11 @@
+# ===================================
+#  Reorder Behavior Config
+# ===================================
+
+title: Reorder categories
+nameFrom: name
+
+modelClass: Aic\Faq\Models\Categories
+
+toolbar:
+    buttons: reorder_toolbar

--- a/controllers/categories/reorder.htm
+++ b/controllers/categories/reorder.htm
@@ -1,0 +1,12 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><?= e(trans('aic.faq::lang.menu.categories')) ?></li>
+        <li>
+            <span class='text-info'><strong><?= Aic\Faq\Models\Categories::all()->count() ?></strong> <?= e(trans('aic.faq::lang.form.total')) ?></span>
+        </li>
+    </ul>
+<?php Block::endPut() ?>
+
+<div style='padding: 0 20px 1px 20px;'>
+    <?= $this->reorderRender() ?>
+</div>

--- a/controllers/settings/config_form.yaml
+++ b/controllers/settings/config_form.yaml
@@ -1,0 +1,9 @@
+# ===================================
+#  Form Behavior Config
+# ===================================
+
+name: aic.faq::lang.title.settings
+form: ~/plugins/aic/faq/models/settings/fields.yaml
+
+modelClass: Aic\Faq\Models\Settings
+defaultRedirect: aic/faq/settings

--- a/controllers/settings/index.htm
+++ b/controllers/settings/index.htm
@@ -1,0 +1,73 @@
+<?php Block::put('breadcrumb') ?>
+    <ul>
+        <li><a href="<?= Backend::url('aic/faq/faqs') ?>"><?= Lang::get('aic.faq::lang.menu.faqs'); ?></a></li>
+        <li><?= ucfirst(e(trans($this->pageTitle))) ?></li>
+    </ul>
+<?php Block::endPut() ?>
+
+<?php if (!$this->fatalError): ?>
+
+    <?php Block::put('form-contents') ?>
+
+        <div class="layout-row min-size">
+            <?= $this->formRenderOutsideFields() ?>
+        </div>
+        <div class="layout-row">
+            <?= $this->formRenderPrimaryTabs() ?>
+        </div>
+
+        <div class="form-buttons">
+            <div class="loading-indicator-container">
+                <button
+                    type="submit"
+                    data-request="onSave"
+                    data-request-data="redirect:0"
+                    data-hotkey="ctrl+s, cmd+s"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-primary">
+                    <?= e(trans('backend::lang.form.save')) ?>
+                </button>
+                <button
+                    type="button"
+                    data-request="onSave"
+                    data-request-data="close:1"
+                    data-hotkey="ctrl+enter, cmd+enter"
+                    data-load-indicator="<?= e(trans('backend::lang.form.saving')) ?>"
+                    class="btn btn-default">
+                    <?= e(trans('backend::lang.form.save_and_close')) ?>
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-danger pull-right"
+                    data-request="onResetDefault"
+                    data-load-indicator="<?= e(trans('backend::lang.form.resetting')) ?>"
+                    data-request-confirm="<?= e(trans('backend::lang.form.action_confirm')) ?>">
+                    <?= e(trans('aic.faq::lang.button.reset_default')) ?>
+                </button>
+                <span class="btn-text">
+                    <?= e(trans('backend::lang.form.or')) ?> <a href="<?= Backend::url('aic/faq/faqs') ?>" class="cancel"><?= e(trans('backend::lang.form.cancel')) ?></a>
+                </span>
+            </div>
+        </div>
+
+    <?php Block::endPut() ?>
+
+    <?php Block::put('form-sidebar') ?>
+        <div class="hide-tabs"><?= $this->formRenderSecondaryTabs() ?></div>
+    <?php Block::endPut() ?>
+
+    <?php Block::put('body') ?>
+        <?= Form::open(['class'=>'layout stretch']) ?>
+            <?= $this->makeLayout('form-with-sidebar') ?>
+        <?= Form::close() ?>
+    <?php Block::endPut() ?>
+
+<?php else: ?>
+    <div class="control-breadcrumb">
+        <?= Block::placeholder('breadcrumb') ?>
+    </div>
+    <div class="padded-container">
+        <p class="flash-message static error"><?= e(trans($this->fatalError)) ?></p>
+        <p><a href="<?= Backend::url('aic/faq/faqs') ?>" class="btn btn-default"><?= e(trans('system::lang.settings.return')) ?></a></p>
+    </div>
+<?php endif ?>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -7,15 +7,18 @@ return [
     ],
     'button' => [
         'return' => 'Return',
-        'reorder' => 'Reorder'
+        'reorder' => 'Reorder',
+        'reset_default' => 'Reset to default'
     ],
     'menu' => [
         'faqs' => 'FAQs',
-        'categories' => 'Categories'
+        'categories' => 'Categories',
+        'settings' => 'Settings'
     ],
     'title' => [
         'faqs' => 'FAQ',
-        'categories' => 'Category'
+        'categories' => 'Category',
+        'settings' => 'Settings'
     ],
     'new' => [
         'faqs' => 'New FAQ',
@@ -26,6 +29,9 @@ return [
         'id' => 'ID',
         'name' => 'Name',
         'slug' => 'Slug',
+        'intro' => 'Introduction',
+        'blocks' => 'Blocks',
+        'blocks_add' => 'Add a block',
         'created_at' => 'Created at',
         'updated_at' => 'Updated at',
         'question' => 'Question',
@@ -111,6 +117,38 @@ return [
                 ]
             ]
         ]
+    ],
+    'settings' => [
+        'title' => 'Title',
+        'intro' => 'Introduction',
+        'no_posts_title' => 'No articles message',
+        'no_posts_description' => 'Message to display when no articles are found.',
+        'no_posts_found' => 'No articles found',
+        'filter_title' => 'Filters',
+        'filter_description' => 'Enable the category filter'
+    ],
+    'fields' => [
+        'tab_meta' => 'Meta',
+        'meta_title' => 'Meta Title',
+        'meta_description' => 'Meta Description',
+        'og' => 'OpenGraph',
+        'og_title' => 'OG Title',
+        'og_description' => 'OG Description',
+        'og_image' => 'OG Image'
+    ],
+    'blocks' => [
+        'text' => 'Text',
+        'title' => 'Title',
+        'subtitle' => 'Subtitle',
+        'type' => 'Type',
+        'type_default' => 'Default',
+        'type_intro' => 'Intro',
+        'color' => 'Background color',
+        'margin' => 'Top margin',
+        'padding' => 'Smaller top spacing',
+        'center' => 'Center text',
+        'on' => 'On',
+        'off' => 'Off'
     ],
     'permission' => [
         'faq' => 'Manage FAQ'

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -6,7 +6,8 @@ return [
         'description' => 'Frequently Asked Questions. Questions and answers. Assign them to a category, add featured statusses and manage which ones are displayed on the frontend.'
     ],
     'button' => [
-        'return' => 'Return'
+        'return' => 'Return',
+        'reorder' => 'Reorder'
     ],
     'menu' => [
         'faqs' => 'FAQs',
@@ -24,6 +25,7 @@ return [
         'total' => 'TOTAL',
         'id' => 'ID',
         'name' => 'Name',
+        'slug' => 'Slug',
         'created_at' => 'Created at',
         'updated_at' => 'Updated at',
         'question' => 'Question',
@@ -83,6 +85,30 @@ return [
                 'title' => 'Search minimum results',
                 'description' => 'Minimum amount of results for the search field to show. Must be a number',
                 'validationMessage' => 'Must be a number'
+            ],
+            'category_slug' => [
+                'title' => 'Category slug',
+                'description' => 'Look up the FAQ category using the supplied slug value and only show FAQs from that category'
+            ]
+        ],
+        'categories' => [
+            'title' => 'FAQ Categories',
+            'description' => 'List of FAQ categories',
+            'all_label' => 'All questions',
+            'settings' => [
+                'links' => 'Links',
+                'slug' => [
+                    'title' => 'Category slug',
+                    'description' => 'Slug of the active category, used to highlight it in the list'
+                ],
+                'overview_page' => [
+                    'title' => 'Overview page',
+                    'description' => 'Page that shows all FAQs'
+                ],
+                'category_page' => [
+                    'title' => 'Category page',
+                    'description' => 'Page that shows the FAQs of one category'
+                ]
             ]
         ]
     ],

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -6,7 +6,8 @@ return [
         'description' => 'Foire aux questions. Questions et réponses. Classez-les par catégorie, attribuez-leur un statut « en vedette » et gérez celles qui s’affichent sur votre site..'
     ],
     'button' => [
-        'return' => 'Retour'
+        'return' => 'Retour',
+        'reorder' => 'Réorganiser'
     ],
     'menu' => [
         'faqs' => 'FAQs',
@@ -24,6 +25,7 @@ return [
         'total' => 'TOTAL',
         'id' => 'ID',
         'name' => 'Nom',
+        'slug' => 'Slug',
         'created_at' => 'Créé le',
         'updated_at' => 'Mis à jour le',
         'question' => 'Question',
@@ -83,6 +85,30 @@ return [
                 'title' => 'Résultats minimum pour la recherche',
                 'description' => 'Nombre minimum de résultats à afficher dans le champ de recherche. Doit être un nombre.',
                 'validationMessage' => 'Doit être un nombre'
+            ],
+            'category_slug' => [
+                'title' => 'Slug de catégorie',
+                'description' => 'Recherche la catégorie de FAQ à partir du slug fourni et affiche uniquement les FAQs de cette catégorie'
+            ]
+        ],
+        'categories' => [
+            'title' => 'Catégories de FAQ',
+            'description' => 'Liste des catégories de FAQ',
+            'all_label' => 'Toutes les questions',
+            'settings' => [
+                'links' => 'Liens',
+                'slug' => [
+                    'title' => 'Slug de catégorie',
+                    'description' => 'Slug de la catégorie active, utilisé pour la mettre en évidence dans la liste'
+                ],
+                'overview_page' => [
+                    'title' => 'Page d’aperçu',
+                    'description' => 'Page qui affiche toutes les FAQs'
+                ],
+                'category_page' => [
+                    'title' => 'Page de catégorie',
+                    'description' => 'Page qui affiche les FAQs d’une catégorie'
+                ]
             ]
         ]
     ],

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -7,15 +7,18 @@ return [
     ],
     'button' => [
         'return' => 'Retour',
-        'reorder' => 'Réorganiser'
+        'reorder' => 'Réorganiser',
+        'reset_default' => 'Rétablir les valeurs par défaut'
     ],
     'menu' => [
         'faqs' => 'FAQs',
-        'categories' => 'Catégories'
+        'categories' => 'Catégories',
+        'settings' => 'Paramètres'
     ],
     'title' => [
         'faqs' => 'FAQ',
-        'categories' => 'Catégorie'
+        'categories' => 'Catégorie',
+        'settings' => 'Paramètres'
     ],
     'new' => [
         'faqs' => 'Nouvelle FAQ',
@@ -26,6 +29,9 @@ return [
         'id' => 'ID',
         'name' => 'Nom',
         'slug' => 'Slug',
+        'intro' => 'Introduction',
+        'blocks' => 'Blocs',
+        'blocks_add' => 'Ajouter un bloc',
         'created_at' => 'Créé le',
         'updated_at' => 'Mis à jour le',
         'question' => 'Question',
@@ -111,6 +117,38 @@ return [
                 ]
             ]
         ]
+    ],
+    'settings' => [
+        'title' => 'Titre',
+        'intro' => 'Introduction',
+        'no_posts_title' => 'Message « aucun article »',
+        'no_posts_description' => 'Message à afficher lorsqu’aucun article n’est trouvé.',
+        'no_posts_found' => 'Aucun article trouvé',
+        'filter_title' => 'Filtres',
+        'filter_description' => 'Activer le filtre par catégorie'
+    ],
+    'fields' => [
+        'tab_meta' => 'Meta',
+        'meta_title' => 'Meta Title',
+        'meta_description' => 'Meta Description',
+        'og' => 'OpenGraph',
+        'og_title' => 'OG Title',
+        'og_description' => 'OG Description',
+        'og_image' => 'OG Image'
+    ],
+    'blocks' => [
+        'text' => 'Texte',
+        'title' => 'Titre',
+        'subtitle' => 'Sous-titre',
+        'type' => 'Type',
+        'type_default' => 'Standard',
+        'type_intro' => 'Introduction',
+        'color' => 'Couleur de fond',
+        'margin' => 'Marge supérieure',
+        'padding' => 'Espacement supérieur réduit',
+        'center' => 'Centrer le texte',
+        'on' => 'Activé',
+        'off' => 'Désactivé'
     ],
     'permission' => [
         'faq' => 'Gérer la FAQ'

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -6,7 +6,8 @@ return [
         'description' => 'Frequently Asked Questions. Vragen en antwoorden. Geef ze een categorie, voeg uitgelichte statussen toe en beheer welke je wil weergeven op de frontend.'
     ],
     'button' => [
-        'return' => 'Vorige'
+        'return' => 'Vorige',
+        'reorder' => 'Herschikken'
     ],
     'menu' => [
         'faqs' => 'FAQs',
@@ -24,6 +25,7 @@ return [
         'total' => 'TOTAAL',
         'id' => 'ID',
         'name' => 'Naam',
+        'slug' => 'Slug',
         'created_at' => 'Aangemaakt op',
         'updated_at' => 'Aangepast op',
         'question' => 'Vraag',
@@ -83,6 +85,30 @@ return [
                 'title' => 'Minimum zoek resultaten',
                 'description' => 'De minimum hoeveelheid zoek resultaten om het zoek veld weer te geven. Moet een nummer zijn.',
                 'validationMessage' => 'Moet een nummer zijn'
+            ],
+            'category_slug' => [
+                'title' => 'Categorie-slug',
+                'description' => 'Zoek de FAQ-categorie op via de opgegeven slug en toon enkel de FAQs van die categorie'
+            ]
+        ],
+        'categories' => [
+            'title' => 'FAQ-categorieën',
+            'description' => 'Lijst van FAQ-categorieën',
+            'all_label' => 'Alle vragen',
+            'settings' => [
+                'links' => 'Links',
+                'slug' => [
+                    'title' => 'Categorie-slug',
+                    'description' => 'Slug van de actieve categorie, gebruikt om die te markeren in de lijst'
+                ],
+                'overview_page' => [
+                    'title' => 'Overzichtspagina',
+                    'description' => 'Pagina die alle FAQs toont'
+                ],
+                'category_page' => [
+                    'title' => 'Categoriepagina',
+                    'description' => 'Pagina die de FAQs van één categorie toont'
+                ]
             ]
         ]
     ],

--- a/lang/nl/lang.php
+++ b/lang/nl/lang.php
@@ -7,15 +7,18 @@ return [
     ],
     'button' => [
         'return' => 'Vorige',
-        'reorder' => 'Herschikken'
+        'reorder' => 'Herschikken',
+        'reset_default' => 'Standaardwaarden herstellen'
     ],
     'menu' => [
         'faqs' => 'FAQs',
-        'categories' => 'Categorieën'
+        'categories' => 'Categorieën',
+        'settings' => 'Instellingen'
     ],
     'title' => [
         'faqs' => 'FAQ',
-        'categories' => 'Categorie'
+        'categories' => 'Categorie',
+        'settings' => 'Instellingen'
     ],
     'new' => [
         'faqs' => 'Nieuwe FAQ',
@@ -26,6 +29,9 @@ return [
         'id' => 'ID',
         'name' => 'Naam',
         'slug' => 'Slug',
+        'intro' => 'Introductie',
+        'blocks' => 'Blokken',
+        'blocks_add' => 'Voeg een blok toe',
         'created_at' => 'Aangemaakt op',
         'updated_at' => 'Aangepast op',
         'question' => 'Vraag',
@@ -111,6 +117,38 @@ return [
                 ]
             ]
         ]
+    ],
+    'settings' => [
+        'title' => 'Titel',
+        'intro' => 'Introductie',
+        'no_posts_title' => 'Geen artikels bericht',
+        'no_posts_description' => 'Bericht om weer te geven wanneer er geen artikels terug zijn gevonden.',
+        'no_posts_found' => 'Geen artikels gevonden',
+        'filter_title' => 'Filters',
+        'filter_description' => 'Schakel de categoriefilter in'
+    ],
+    'fields' => [
+        'tab_meta' => 'Meta',
+        'meta_title' => 'Meta Title',
+        'meta_description' => 'Meta Description',
+        'og' => 'OpenGraph',
+        'og_title' => 'OG Title',
+        'og_description' => 'OG Description',
+        'og_image' => 'OG Afbeelding'
+    ],
+    'blocks' => [
+        'text' => 'Tekst',
+        'title' => 'Titel',
+        'subtitle' => 'Subtitel',
+        'type' => 'Type',
+        'type_default' => 'Standaard',
+        'type_intro' => 'Inleiding',
+        'color' => 'Achtergrondkleur',
+        'margin' => 'Marge bovenaan',
+        'padding' => 'Kleinere afstand bovenaan',
+        'center' => 'Centreer tekst',
+        'on' => 'Aan',
+        'off' => 'Uit'
     ],
     'permission' => [
         'faq' => 'Beheer FAQ'

--- a/models/Categories.php
+++ b/models/Categories.php
@@ -3,7 +3,9 @@ use Model;
 
 class Categories extends Model
 {
+    use \Winter\Storm\Database\Traits\Sluggable;
     use \Winter\Storm\Database\Traits\Validation;
+    use \Winter\Storm\Database\Traits\Sortable;
 
     protected $table = 'aic_faq_categories';
 
@@ -12,12 +14,28 @@ class Categories extends Model
     ];
 
     public $rules = [
-        'name' => 'required'
+        'name' => 'required',
+        'slug' => ['required', 'regex:/^[a-z0-9\/\:_\-\*\[\]\+\?\|]*$/i', 'unique:aic_faq_categories']
+    ];
+
+    protected $slugs = [
+        'slug' => 'name'
     ];
 
     public $translatable = [
-        'name'
+        'name',
+        ['slug', 'index' => true]
     ];
+
+    /**************************************/
+    // Set sort_order manually
+    /**************************************/
+    public function beforeValidate()
+    {
+        if ($this->sort_order === null) {
+            $this->sort_order = static::max('sort_order') + 1;
+        }
+    }
 
     /**************************************/
     // Get dropdown options
@@ -25,5 +43,24 @@ class Categories extends Model
     public function getCategoryOptions()
     {
         return Categories::orderBy('name', 'asc')->lists('name', 'id');
+    }
+
+    /**************************************/
+    // URL parameter and query string translation
+    /**************************************/
+    public static function translateParams($params, $oldLocale, $newLocale)
+    {
+        $newParams = $params;
+        foreach ($params as $paramName => $paramValue) {
+            if ($paramName === 'page') {
+                continue;
+            }
+
+            $records = self::transWhere($paramName, $paramValue, $oldLocale)->first();
+            if ($records) {
+                $newParams[$paramName] = $records->getAttributeTranslated($paramName, $newLocale);
+            }
+        }
+        return $newParams;
     }
 }

--- a/models/Faqs.php
+++ b/models/Faqs.php
@@ -155,6 +155,7 @@ class Faqs extends Model
 
             // sort the query
             $query->orderBy($sort[0], $sort[1]);
+            $query->orderBy('created_at', 'ASC');
 
         }
 

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,20 @@
+<?php namespace Aic\Faq\Models;
+use Winter\Storm\Database\Model;
+
+class Settings extends Model
+{
+    public $implement = ['@Winter.Translate.Behaviors.TranslatableModel', '@System.Behaviors.SettingsModel'];
+    public $settingsCode = 'aic_faq_settings';
+    public $settingsFields = 'fields.yaml';
+
+    public $translatable = [
+        'meta_title',
+        'meta_description',
+        'og_title',
+        'og_description',
+        'og_image',
+        'title',
+        'intro',
+        'blocks'
+    ];
+}

--- a/models/categories/_published_status.htm
+++ b/models/categories/_published_status.htm
@@ -1,0 +1,15 @@
+<?php
+
+    $text = [
+        0 => 'not_published',
+        1 => 'published',
+    ];
+
+    $class = [
+        0 => 'text-danger',
+        1 => 'text-success',
+    ];
+
+?>
+
+<span class='wn-icon-circle <?= $class[$record->is_published] ?>'><?= Lang::get('aic.faq::lang.form.published_status.' . $text[$record->is_published]) ?></span>

--- a/models/categories/columns.yaml
+++ b/models/categories/columns.yaml
@@ -12,13 +12,24 @@ columns:
         label: aic.faq::lang.form.name
         searchable: true
 
+    slug:
+        label: aic.faq::lang.form.slug
+        searchable: true
+        invisible: true
+
+    is_published:
+        label: aic.faq::lang.form.published_status.title
+        sortable: false
+        type: partial
+        path: ~/plugins/aic/faq/models/categories/_published_status.htm
+
     created_at:
         label: aic.faq::lang.form.created_at
         type: datetime
         format: d/m/Y
         searchable: true
         invisible: true
-        
+
     updated_at:
         label: aic.faq::lang.form.updated_at
         type: datetime

--- a/models/categories/fields.yaml
+++ b/models/categories/fields.yaml
@@ -8,22 +8,22 @@ fields:
         label: aic.faq::lang.form.name
         span: auto
 
-# secondaryTabs:
+    slug:
+        label: aic.faq::lang.form.slug
+        preset: name
+        span: auto
 
-#     fields:
+secondaryTabs:
 
-#         created_at:
-#             label: aic.faq::lang.form.created_at
-#             type: datepicker
-#             mode: date
-#             format: Y/m/d
-#             minDate: now
-#             default: now
+    fields:
 
-#         updated_at:
-#             label: aic.faq::lang.form.updated_at
-#             type: datepicker
-#             mode: date
-#             format: Y/m/d
-#             minDate: now
-#             default: now
+        published_section:
+            type: section
+            label: aic.faq::lang.form.published_status.title
+
+        is_published:
+            type: balloon-selector
+            options:
+                1: aic.faq::lang.form.published_status.published
+                0: aic.faq::lang.form.published_status.not_published
+            default: 1

--- a/models/faqs/fields.yaml
+++ b/models/faqs/fields.yaml
@@ -40,19 +40,10 @@ secondaryTabs:
                 1: aic.faq::lang.form.featured_status.featured
                 0: aic.faq::lang.form.featured_status.not_featured
             default: 0
-        
-#         created_at:
-#             label: aic.faq::lang.form.created_at
-#             type: datepicker
-#             mode: date
-#             format: Y/m/d
-#             minDate: now
-#             default: now
 
-#         updated_at:
-#             label: aic.faq::lang.form.updated_at
-#             type: datepicker
-#             mode: date
-#             format: Y/m/d
-#             minDate: now
-#             default: now
+        created_at:
+            label: aic.faq::lang.form.created_at
+            type: datepicker
+            mode: date
+            format: Y/m/d
+            default: now

--- a/models/settings/blocks.yaml
+++ b/models/settings/blocks.yaml
@@ -1,0 +1,74 @@
+# ===================================
+#  Block group definitions
+#
+#  Rendering is up to the consuming theme: the FAQ component exposes the
+#  saved blocks as `blocks`. Themes with their own block system can point
+#  the repeater at their own groups file by overriding this field.
+# ===================================
+
+block_text:
+    name: aic.faq::lang.blocks.text
+    icon: icon-bars
+    fields:
+        type:
+            label: aic.faq::lang.blocks.type
+            type: balloon-selector
+            default: default
+            options:
+                default: aic.faq::lang.blocks.type_default
+                intro: aic.faq::lang.blocks.type_intro
+            span: storm
+            cssClass: col-xs-4
+        color:
+            label: aic.faq::lang.blocks.color
+            type: balloon-selector
+            default: 0
+            options:
+                0: aic.faq::lang.blocks.off
+                1: aic.faq::lang.blocks.on
+            span: storm
+            cssClass: col-xs-4
+        margin:
+            label: aic.faq::lang.blocks.margin
+            type: balloon-selector
+            default: 1
+            options:
+                0: aic.faq::lang.blocks.off
+                1: aic.faq::lang.blocks.on
+            span: storm
+            cssClass: col-xs-4
+        padding:
+            label: aic.faq::lang.blocks.padding
+            type: balloon-selector
+            default: 0
+            options:
+                0: aic.faq::lang.blocks.off
+                1: aic.faq::lang.blocks.on
+            span: storm
+            cssClass: col-xs-4
+        center:
+            label: aic.faq::lang.blocks.center
+            type: balloon-selector
+            default: 0
+            options:
+                0: aic.faq::lang.blocks.off
+                1: aic.faq::lang.blocks.on
+            span: storm
+            cssClass: col-xs-4
+        data:
+            type: nestedform
+            usePanelStyles: false
+            form:
+                fields:
+                    block_title:
+                        label: aic.faq::lang.blocks.title
+                        type: text
+                        span: auto
+                    subtitle:
+                        label: aic.faq::lang.blocks.subtitle
+                        type: text
+                        span: auto
+                    text:
+                        label: aic.faq::lang.blocks.text
+                        type: richeditor
+                        size: large

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -1,0 +1,76 @@
+# ===================================
+#  Field Definitions
+# ===================================
+
+tabs:
+
+    icons:
+        aic.faq::lang.fields.tab_meta: icon-search
+        aic.faq::lang.form.intro: icon-address-card-o
+        aic.faq::lang.form.blocks: icon-hammer
+
+    fields:
+
+        title:
+            tab: aic.faq::lang.form.intro
+            label: aic.faq::lang.settings.title
+            type: text
+            span: auto
+
+        intro:
+            tab: aic.faq::lang.form.intro
+            label: aic.faq::lang.settings.intro
+            type: richeditor
+            size: small
+            span: auto
+
+        blocks:
+            tab: aic.faq::lang.form.blocks
+            prompt: aic.faq::lang.form.blocks_add
+            type: repeater
+            cssClass: secondary-tab
+            stretch: true
+            style: collapsed
+            groups: $/aic/faq/models/settings/blocks.yaml
+
+secondaryTabs:
+
+    fields:
+
+        meta_section:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.tab_meta
+            type: section
+
+        meta_title:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.meta_title
+            type: text
+
+        meta_description:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.meta_description
+            type: textarea
+            size: small
+
+        og_section:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.og
+            type: section
+
+        og_title:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.og_title
+            type: text
+
+        og_description:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.og_description
+            type: textarea
+            size: small
+
+        og_image:
+            tab: aic.faq::lang.fields.tab_meta
+            label: aic.faq::lang.fields.og_image
+            type: mediafinder
+            mode: image

--- a/updates/add_category_publishing_columns.php
+++ b/updates/add_category_publishing_columns.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Aic\Faq\Updates;
+
+use Winter\Storm\Database\Updates\Migration;
+use Winter\Storm\Support\Str;
+use Schema;
+use Db;
+
+class AddCategoryPublishingColumns extends Migration
+{
+    public function up()
+    {
+        if (!Schema::hasColumn('aic_faq_categories', 'sort_order')) {
+            Schema::table('aic_faq_categories', function ($table) {
+                $table->integer('sort_order')->default(1)->index();
+            });
+        }
+
+        if (!Schema::hasColumn('aic_faq_categories', 'is_published')) {
+            Schema::table('aic_faq_categories', function ($table) {
+                $table->integer('is_published')->default(1);
+            });
+        }
+
+        if (!Schema::hasColumn('aic_faq_categories', 'slug')) {
+            Schema::table('aic_faq_categories', function ($table) {
+                $table->string('slug', 100)->nullable()->index();
+            });
+        }
+
+        // generate slugs and sort order for existing categories
+        $categories = Db::table('aic_faq_categories')->whereNull('slug')->get();
+        foreach ($categories as $category) {
+            Db::table('aic_faq_categories')->where('id', $category->id)->update([
+                'slug' => Str::slug($category->name),
+                'sort_order' => $category->id,
+            ]);
+        }
+    }
+
+    public function down()
+    {
+        foreach (['sort_order', 'is_published', 'slug'] as $column) {
+            if (Schema::hasColumn('aic_faq_categories', $column)) {
+                Schema::table('aic_faq_categories', function ($table) use ($column) {
+                    $table->dropColumn($column);
+                });
+            }
+        }
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,4 +5,5 @@
     - create_categories_table.php
 1.1.0:
     - Restore the FAQ Categories component (faqCategories) with slug and publishing support
+    - Restore the FAQ Settings page (title, intro, blocks, meta)
     - add_category_publishing_columns.php

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -3,3 +3,6 @@
     - create_faqs_table.php
     - Create Categories table
     - create_categories_table.php
+1.1.0:
+    - Restore the FAQ Categories component (faqCategories) with slug and publishing support
+    - add_category_publishing_columns.php


### PR DESCRIPTION
## Why

The maatkastenonline site had been running a vendored fork of this plugin since 2022 that included a `faqCategories` component, category-slug filtering, an FAQ Settings page and category publishing/ordering. The published package never received those changes, so updating the site to the package silently rolled the plugin back ~4 years and broke the FAQ pages with:

> `Winter\Storm\Exception\SystemException: Class name is not registered for the component "faqCategories"`

(Sentry: MAATKASTENONLINE-PHP-BR)

This PR brings the package back to feature parity with what the site actually ran. Site-specific styling/markup stays out — themes override the component partials.

## Added
* `Categories` component, registered as **faqCategories** — lists published categories with overview/category page links (generic, unstyled partial)
* `categorySlug` property on the `Faqs` component — filters FAQs by a category slug from the URL (translated slugs supported via `transWhere`)
* **FAQ Settings backend page** — title, intro, blocks repeater and meta/OG fields, all translatable; the component exposes `title`/`intro`/`blocks` and sets page meta. The blocks repeater ships a self-contained `block_text` group; themes with their own block system can override the groups file (rendering is up to the theme)
* `boot()` listener for `translate.localePicker.translateParams` — the Winter.Translate locale picker translates the category slug on pages using the FAQ/faqCategories components (generic `hasComponent` check)
* Migration `add_category_publishing_columns.php` (v1.1.0) — adds `slug`, `is_published`, `sort_order` to `aic_faq_categories`, guarded by `hasColumn`; backfills slugs for existing rows
* Backend: slug + published fields on the category form, published column, reorder support, `created_at` datepicker on the FAQ form
* Lang keys (EN/NL/FR) for all of the above

## Changed
* `Categories` model: restored `Sluggable`, `Sortable`, `is_published`, translatable slug and `translateParams()`
* `Faqs` model: secondary `orderBy created_at ASC` for stable FAQ ordering within categories

## Fixed
* Settings controller `onResetDefault` called `instance()` on the controller instead of the Settings model (latent bug in the original vendored code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)